### PR TITLE
fix: allow `SubscribeDirective` to be GCed

### DIFF
--- a/projects/ngneat/subscribe/src/lib/subscribe.directive.ts
+++ b/projects/ngneat/subscribe/src/lib/subscribe.directive.ts
@@ -22,7 +22,7 @@ type IfAny<T, Y, N> = 0 extends (1 & T) ? Y : N;
   selector: '[subscribe]',
 })
 export class SubscribeDirective<T, InitialSyncValue extends boolean = true> implements OnInit, OnDestroy {
-  private subscription: Subscription | undefined;
+  private subscription: Subscription | null = null;
 
   private context: SubscribeContext<any> = {
     $implicit: undefined,
@@ -78,6 +78,7 @@ export class SubscribeDirective<T, InitialSyncValue extends boolean = true> impl
 
   ngOnDestroy() {
     this.subscription?.unsubscribe();
+    this.subscription = null;
   }
 }
 


### PR DESCRIPTION
Hey. `this` is still captured within the `destination` property:

![Screenshot from 2021-09-15 19-13-43](https://user-images.githubusercontent.com/7337691/133470556-62342951-bfb9-48c9-a069-11a77d4b387a.png)

`__ngContext__[2] & 256` is `lView[FLAGS] & LViewFlags.Destroyed`, which checks if the directive is in destroyed status (it is):

![Screenshot from 2021-09-15 19-29-14](https://user-images.githubusercontent.com/7337691/133472701-869037cd-3413-4f44-9777-edb26c303c9a.png)
